### PR TITLE
upgrade to swagger-codegen-cli:2.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # swagger-nodegen-cli
 
-A convenience package for the **node/npm** environment that wraps the Java library [**swagger-codegen-cli-2.4.2.jar**](http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.2/swagger-codegen-cli-2.4.2.jar).
+A convenience package for the **node/npm** environment that wraps the Java library [**swagger-codegen-cli-2.4.4.jar**](http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.2/swagger-codegen-cli-2.4.2.jar).
 
 ## Prerequisites
 

--- a/bin/swagger-codegen-cli.js
+++ b/bin/swagger-codegen-cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 require('child_process')
   .spawn('java', [
-    '-jar', __dirname + '/swagger-codegen-cli-2.4.2.jar']
+    '-jar', __dirname + '/swagger-codegen-cli-2.4.4.jar']
       .concat(process.argv.slice(2)), {stdio: 'inherit'})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swagger-nodegen-cli",
-  "version": "2.4.3",
-  "description": "A simple convenience package that wraps the swagger-codegen-cli-2.4.2 for the node/npm environment.",
+  "version": "2.4.4",
+  "description": "A simple convenience package that wraps the swagger-codegen-cli-2.4.4 for the node/npm environment.",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hello,

We use you swagger-nodegen-cli for angular development but are hitting https://github.com/swagger-api/swagger-codegen/issues/9268, which is fixed in 2.4.3 (your 2.4.3 version wraps swagger-codegen-cli 2.4.2)
I took the liberty of creating a pull request with the required changes.
Please review ( I have only a few days of node experience) + validate my included jar isn't fishy :)