### PR TITLE
Update internal swagger-codegen-cli to 3.0.63

### DIFF
--- a/bin/swagger-codegen-cli.js
+++ b/bin/swagger-codegen-cli.js
@@ -5,5 +5,5 @@ if (argv.length == 2) {
 }
 require('child_process')
   .spawn('java', [
-    '-jar', __dirname + '/swagger-codegen-cli-3.0.35.jar']
-      .concat(argv.slice(2)), { stdio: 'inherit' });
+    '-jar', __dirname + '/swagger-codegen-cli-3.0.63.jar']
+    .concat(argv.slice(2)), { stdio: 'inherit' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,33 @@
 {
-  "name": "swagger-nodegen-cli",
-  "version": "3.0.35",
+  "dependencies": {
+    "user": {
+      "integrity": "sha1-8n8bI/xRHyqO+kDbVc+6Ejgk4Co=",
+      "resolved": "https://registry.npmjs.org/user/-/user-0.0.0.tgz",
+      "version": "0.0.0"
+    }
+  },
   "lockfileVersion": 2,
-  "requires": true,
+  "name": "swagger-nodegen-cli",
   "packages": {
     "": {
-      "name": "swagger-nodegen-cli",
-      "version": "3.0.35",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "user": "^0.0.0"
-      },
       "bin": {
         "sc": "bin/swagger-codegen-cli.js",
         "swagger-codegen-cli": "bin/swagger-codegen-cli.js",
         "swagger-nodegen-cli": "bin/swagger-codegen-cli.js"
-      }
+      },
+      "dependencies": {
+        "user": "^0.0.0"
+      },
+      "license": "Apache-2.0",
+      "name": "swagger-nodegen-cli",
+      "version": "3.0.63"
     },
     "node_modules/user": {
-      "version": "0.0.0",
+      "integrity": "sha1-8n8bI/xRHyqO+kDbVc+6Ejgk4Co=",
       "resolved": "https://registry.npmjs.org/user/-/user-0.0.0.tgz",
-      "integrity": "sha1-8n8bI/xRHyqO+kDbVc+6Ejgk4Co="
+      "version": "0.0.0"
     }
   },
-  "dependencies": {
-    "user": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/user/-/user-0.0.0.tgz",
-      "integrity": "sha1-8n8bI/xRHyqO+kDbVc+6Ejgk4Co="
-    }
-  }
+  "requires": true,
+  "version": "3.0.63"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-nodegen-cli",
-  "version": "3.0.35",
+  "version": "3.0.63",
   "description": "A simple convenience package that wraps the swagger-codegen-cli for the node/npm environment.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Hi,

this PR updates the swagger-codegen-cli to 3.0.63. The newer swagger-codegen-cli fixes a lot of bugs.
The jar file was simply downloaded from maven central https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.63/swagger-codegen-cli-3.0.63.jar - there is also a checksum file to check the correctness of it.

Please consider accepting it and release a new version. TIA

Best regards
Matti